### PR TITLE
fix: Shade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -374,28 +374,28 @@
           </execution>
         </executions>
       </plugin>
-<!--      <plugin>-->
-<!--        <groupId>org.apache.maven.plugins</groupId>-->
-<!--        <artifactId>maven-gpg-plugin</artifactId>-->
-<!--        <version>3.1.0</version>-->
-<!--        <configuration>-->
-<!--          &lt;!&ndash; Prevent gpg from using pinentry programs &ndash;&gt;-->
-<!--          <gpgArguments>-->
-<!--            <arg>&#45;&#45;pinentry-mode</arg>-->
-<!--            <arg>loopback</arg>-->
-<!--            <arg>&#45;&#45;no-tty</arg>-->
-<!--          </gpgArguments>-->
-<!--        </configuration>-->
-<!--        <executions>-->
-<!--          <execution>-->
-<!--            <id>sign-artifacts</id>-->
-<!--            <phase>install</phase>-->
-<!--            <goals>-->
-<!--              <goal>sign</goal>-->
-<!--            </goals>-->
-<!--          </execution>-->
-<!--        </executions>-->
-<!--      </plugin>-->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <!-- Prevent gpg from using pinentry programs -->
+          <gpgArguments>
+            <arg>--pinentry-mode</arg>
+            <arg>loopback</arg>
+            <arg>--no-tty</arg>
+          </gpgArguments>
+        </configuration>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>install</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,14 @@
       <version>1.6.1</version>
     </dependency>
 
+    <!-- runtime scope -->
+    <dependency>
+      <groupId>io.perfmark</groupId>
+      <artifactId>perfmark-api</artifactId>
+      <version>0.26.0</version>
+      <scope>runtime</scope>
+    </dependency>
+
     <!-- test scope -->
     <dependency>
       <groupId>org.assertj</groupId>
@@ -374,10 +382,6 @@
               </transformers>
               <relocations>
                 <relocation>
-                  <pattern>google</pattern>
-                  <shadedPattern>com.spotify.confidence.shaded.google</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>com.google</pattern>
                   <shadedPattern>com.spotify.confidence.shaded.com.google</shadedPattern>
                 </relocation>
@@ -392,6 +396,10 @@
                   <exclude>org.slf4j:slf4j-api</exclude>
                   <exclude>javax.annotation:javax.annotation-api</exclude>
                   <exclude>org.checkerframework:checker-qual</exclude>
+                  <exclude>com.google.code.findbugs:jsr305</exclude>
+                  <exclude>com.google.android:annotations</exclude>
+                  <exclude>org.codehaus.mojo:animal-sniffer-annotations</exclude>
+                  <exclude>io.perfmark:perfmark-api</exclude>
                 </excludes>
               </artifactSet>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -105,11 +105,6 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-core</artifactId>
-      <version>${grpc.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
       <version>${grpc.version}</version>
     </dependency>
@@ -138,12 +133,53 @@
       <artifactId>sdk</artifactId>
       <version>1.6.1</version>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+    </dependency>
 
-    <!-- runtime scope -->
+    <!-- runtime scope-->
+    <!-- transitive deps to shaded libs brought with runtime to be safe -->
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+      <version>${grpc.version}</version>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>io.perfmark</groupId>
       <artifactId>perfmark-api</artifactId>
       <version>0.26.0</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.9</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
+      <version>3.33.0</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.android</groupId>
+      <artifactId>annotations</artifactId>
+      <version>4.1.1.4</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>animal-sniffer-annotations</artifactId>
+      <version>1.23</version>
       <scope>runtime</scope>
     </dependency>
 
@@ -259,15 +295,12 @@
               <ignoreNonCompile>true</ignoreNonCompile>
               <ignoredUnusedDeclaredDependencies>
                 <ignoredUnusedDeclaredDependency>com.google.api.grpc:grpc-google-common-protos</ignoredUnusedDeclaredDependency>
+                <ignoredUnusedDeclaredDependency>com.google.code.findbugs:jsr305</ignoredUnusedDeclaredDependency>
+                <ignoredUnusedDeclaredDependency>javax.annotation:javax.annotation-api</ignoredUnusedDeclaredDependency>
               </ignoredUnusedDeclaredDependencies>
               <ignoredUsedUndeclaredDependencies>
-                <ignoredUnusedDeclaredDependency>com.google.code.findbugs:jsr305</ignoredUnusedDeclaredDependency>
                 <ignoredUnusedDeclaredDependency>com.google.guava:guava</ignoredUnusedDeclaredDependency>
-                <ignoredUnusedDeclaredDependency>io.grpc:grpc-core</ignoredUnusedDeclaredDependency>
               </ignoredUsedUndeclaredDependencies>
-              <ignoredNonTestScopedDependencies>
-                <ignoredNonTestScopedDependency>io.grpc:grpc-core</ignoredNonTestScopedDependency>
-              </ignoredNonTestScopedDependencies>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -330,25 +330,64 @@
           </execution>
         </executions>
       </plugin>
+<!--      <plugin>-->
+<!--        <groupId>org.apache.maven.plugins</groupId>-->
+<!--        <artifactId>maven-gpg-plugin</artifactId>-->
+<!--        <version>3.1.0</version>-->
+<!--        <configuration>-->
+<!--          &lt;!&ndash; Prevent gpg from using pinentry programs &ndash;&gt;-->
+<!--          <gpgArguments>-->
+<!--            <arg>&#45;&#45;pinentry-mode</arg>-->
+<!--            <arg>loopback</arg>-->
+<!--            <arg>&#45;&#45;no-tty</arg>-->
+<!--          </gpgArguments>-->
+<!--        </configuration>-->
+<!--        <executions>-->
+<!--          <execution>-->
+<!--            <id>sign-artifacts</id>-->
+<!--            <phase>install</phase>-->
+<!--            <goals>-->
+<!--              <goal>sign</goal>-->
+<!--            </goals>-->
+<!--          </execution>-->
+<!--        </executions>-->
+<!--      </plugin>-->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>3.1.0</version>
-        <configuration>
-          <!-- Prevent gpg from using pinentry programs -->
-          <gpgArguments>
-            <arg>--pinentry-mode</arg>
-            <arg>loopback</arg>
-            <arg>--no-tty</arg>
-          </gpgArguments>
-        </configuration>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.1</version>
         <executions>
           <execution>
-            <id>sign-artifacts</id>
-            <phase>install</phase>
+            <phase>package</phase>
             <goals>
-              <goal>sign</goal>
+              <goal>shade</goal>
             </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                  <resource>.proto</resource>
+                </transformer>
+              </transformers>
+              <relocations>
+                <relocation>
+                  <pattern>com.google</pattern>
+                  <shadedPattern>com.spotify.confidence.shaded.com.google</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.grpc</pattern>
+                  <shadedPattern>com.spotify.confidence.shaded.io.grpc</shadedPattern>
+                </relocation>
+              </relocations>
+              <artifactSet>
+                <excludes>
+                  <exclude>dev.openfeature:sdk</exclude>
+                  <exclude>org.slf4j:slf4j-api</exclude>
+                  <exclude>javax.annotation:javax.annotation-api</exclude>
+                  <exclude>org.checkerframework:checker-qual</exclude>
+                  <exclude>io.perfmark:perfmark-api</exclude>
+                </excludes>
+              </artifactSet>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -377,8 +377,12 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                   <resource>.proto</resource>
+                  <resource>checkstyle.xml</resource>
                 </transformer>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                  <addHeader>true</addHeader>
+                </transformer>
               </transformers>
               <relocations>
                 <relocation>

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,11 @@
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+      <version>${grpc.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
       <artifactId>grpc-api</artifactId>
       <version>${grpc.version}</version>
     </dependency>
@@ -158,12 +163,6 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
       <version>${mockito.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.grpc</groupId>
-      <artifactId>grpc-core</artifactId>
-      <scope>test</scope>
-      <version>${grpc.version}</version>
     </dependency>
   </dependencies>
 
@@ -256,7 +255,11 @@
               <ignoredUsedUndeclaredDependencies>
                 <ignoredUnusedDeclaredDependency>com.google.code.findbugs:jsr305</ignoredUnusedDeclaredDependency>
                 <ignoredUnusedDeclaredDependency>com.google.guava:guava</ignoredUnusedDeclaredDependency>
+                <ignoredUnusedDeclaredDependency>io.grpc:grpc-core</ignoredUnusedDeclaredDependency>
               </ignoredUsedUndeclaredDependencies>
+              <ignoredNonTestScopedDependencies>
+                <ignoredNonTestScopedDependency>io.grpc:grpc-core</ignoredNonTestScopedDependency>
+              </ignoredNonTestScopedDependencies>
             </configuration>
           </execution>
         </executions>
@@ -367,8 +370,13 @@
                 <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
                   <resource>.proto</resource>
                 </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <relocations>
+                <relocation>
+                  <pattern>google</pattern>
+                  <shadedPattern>com.spotify.confidence.shaded.google</shadedPattern>
+                </relocation>
                 <relocation>
                   <pattern>com.google</pattern>
                   <shadedPattern>com.spotify.confidence.shaded.com.google</shadedPattern>
@@ -384,7 +392,6 @@
                   <exclude>org.slf4j:slf4j-api</exclude>
                   <exclude>javax.annotation:javax.annotation-api</exclude>
                   <exclude>org.checkerframework:checker-qual</exclude>
-                  <exclude>io.perfmark:perfmark-api</exclude>
                 </excludes>
               </artifactSet>
             </configuration>


### PR DESCRIPTION
This PR shades some dependencies (mainly aimed at `io.grpc` and `com.google.protobuf`) in effort to remove collisions for consumers using those libs.