### PR TITLE
feat: add logging with slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,11 @@
       <artifactId>jsr305</artifactId>
       <version>3.0.2</version>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.12</version>
+    </dependency>
 
     <!-- runtime scope-->
     <!-- transitive deps to shaded libs brought with runtime to be safe -->
@@ -161,12 +166,6 @@
       <groupId>io.perfmark</groupId>
       <artifactId>perfmark-api</artifactId>
       <version>0.26.0</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>2.0.9</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -189,6 +188,12 @@
     </dependency>
 
     <!-- test scope -->
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+      <version>1.4.14</version>
+    </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>

--- a/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.java
+++ b/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.java
@@ -219,18 +219,19 @@ public class ConfidenceFeatureProvider implements FeatureProvider {
 
   private static void handleStatusRuntimeException(StatusRuntimeException e) {
     if (e.getStatus().getCode() == Code.DEADLINE_EXCEEDED) {
-      log.error("Deadline exceeded when calling provider backend");
+      log.error("Deadline exceeded when calling provider backend", e);
       throw new GeneralError("Deadline exceeded when calling provider backend");
     } else if (e.getStatus().getCode() == Code.UNAVAILABLE) {
-      log.error("Provider backend is unavailable");
+      log.error("Provider backend is unavailable", e);
       throw new GeneralError("Provider backend is unavailable");
     } else if (e.getStatus().getCode() == Code.UNAUTHENTICATED) {
-      log.error("UNAUTHENTICATED");
+      log.error("UNAUTHENTICATED", e);
       throw new GeneralError("UNAUTHENTICATED");
     } else {
       log.error(
           "Unknown error occurred when calling the provider backend. Grpc status code {}",
-          e.getStatus().getCode());
+          e.getStatus().getCode(),
+          e);
       throw new GeneralError(
           String.format(
               "Unknown error occurred when calling the provider backend. Exception: %s",

--- a/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.java
+++ b/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.java
@@ -178,9 +178,11 @@ public class ConfidenceFeatureProvider implements FeatureProvider {
       final ResolvedFlag resolvedFlag = resolveFlagResponse.getResolvedFlags(0);
 
       if (resolvedFlag.getVariant().isEmpty()) {
-        log.info(
-            "The server returned no assignment for the flag. Typically, this happens "
-                + "if no configured rules matches the given evaluation context.");
+        log.debug(
+            String.format(
+                "The server returned no assignment for the flag '%s'. Typically, this happens "
+                    + "if no configured rules matches the given evaluation context.",
+                flagPath.getFlag()));
         return ProviderEvaluation.<Value>builder()
             .value(defaultValue)
             .reason(

--- a/src/main/java/com/spotify/confidence/GrpcEventUploader.java
+++ b/src/main/java/com/spotify/confidence/GrpcEventUploader.java
@@ -6,9 +6,11 @@ import com.spotify.confidence.events.v1.Event;
 import com.spotify.confidence.events.v1.EventsServiceGrpc;
 import com.spotify.confidence.events.v1.PublishEventsRequest;
 import io.grpc.ManagedChannel;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
 
 class GrpcEventUploader implements EventUploader {
 
@@ -17,6 +19,8 @@ class GrpcEventUploader implements EventUploader {
   private final ManagedChannel managedChannel;
   private final EventsServiceGrpc.EventsServiceFutureStub stub;
   private final Clock clock;
+
+  private static final Logger log = org.slf4j.LoggerFactory.getLogger(GrpcEventUploader.class);
 
   GrpcEventUploader(String clientSecret, Clock clock, ManagedChannel managedChannel) {
     this.clientSecret = clientSecret;
@@ -48,11 +52,28 @@ class GrpcEventUploader implements EventUploader {
 
     return GrpcUtil.toCompletableFuture(
             stub.withDeadlineAfter(5, TimeUnit.SECONDS).publishEvents(request))
-        .thenApply(publishEventsResponse -> true)
+        .thenApply(
+            publishEventsResponse -> {
+              final List<Event> eventsInRequest = request.getEventsList();
+              if (publishEventsResponse.getErrorsCount() == 0) {
+                log.debug(
+                    String.format("Successfully published %d events", eventsInRequest.size()));
+              } else {
+                log.error(
+                    String.format(
+                        "Published batch with %d events, of which %d failed. Failed events are of type: %s",
+                        eventsInRequest.size(),
+                        publishEventsResponse.getErrorsCount(),
+                        publishEventsResponse.getErrorsList().stream()
+                            .map(e -> eventsInRequest.get(e.getIndex()).getEventDefinition())
+                            .collect(Collectors.toSet())));
+              }
+              return true;
+            })
         .exceptionally(
             (throwable -> {
-              // TODO update to use some user-configurable logging
-              throwable.printStackTrace();
+              log.error(
+                  String.format("Publishing batch failed with reason: %s", throwable.getMessage()));
               return false;
             }));
   }

--- a/src/main/java/com/spotify/confidence/GrpcEventUploader.java
+++ b/src/main/java/com/spotify/confidence/GrpcEventUploader.java
@@ -73,7 +73,8 @@ class GrpcEventUploader implements EventUploader {
         .exceptionally(
             (throwable -> {
               log.error(
-                  String.format("Publishing batch failed with reason: %s", throwable.getMessage()));
+                  String.format("Publishing batch failed with reason: %s", throwable.getMessage()),
+                  throwable);
               return false;
             }));
   }


### PR DESCRIPTION
Adds some logging output using slf4j.

Levels may need to be corrected.

Sample logs for Events:
```
16:41:06.948 [main] ERROR c.s.confidence.GrpcEventUploader - Published batch with 4 events, of which 1 failed. Failed events are of type: [event1]
16:41:06.980 [main] DEBUG c.s.confidence.GrpcEventUploader - Successfully published 4 events
16:41:06.983 [main] DEBUG c.s.confidence.GrpcEventUploader - Successfully published 1 events
16:41:06.986 [main] ERROR c.s.confidence.GrpcEventUploader - Publishing batch failed with reason: io.grpc.StatusRuntimeException: UNKNOWN
16:41:06.988 [main] DEBUG c.s.confidence.GrpcEventUploader - Successfully published 1 events
```