### PR TITLE
feat: Limit ConfidenceValue.List to supported types

### DIFF
--- a/src/main/java/com/spotify/confidence/ConfidenceValue.java
+++ b/src/main/java/com/spotify/confidence/ConfidenceValue.java
@@ -7,14 +7,15 @@ import com.google.protobuf.ListValue;
 import com.google.protobuf.NullValue;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public abstract class ConfidenceValue {
+public abstract class ConfidenceValue<T> {
+
+  private T value;
 
   static final ConfidenceValue NULL_VALUE =
-      new ConfidenceValue() {
+      new ConfidenceValue<>() {
 
         @Override
         public boolean isNull() {
@@ -97,52 +98,70 @@ public abstract class ConfidenceValue {
     throw new IllegalStateException("Not a ListValue");
   }
 
-  public static ConfidenceValue of(int value) {
+  public static ConfidenceValue<java.lang.Integer> of(int value) {
     return new Integer(value);
   }
 
-  public static ConfidenceValue of(double value) {
+  public static ConfidenceValue<java.lang.Double> of(double value) {
     return new Double(value);
   }
 
-  public static ConfidenceValue of(Instant value) {
+  public static ConfidenceValue<Instant> of(Instant value) {
     return new Timestamp(value);
   }
 
-  public static ConfidenceValue of(LocalDate date) {
+  public static ConfidenceValue<LocalDate> of(LocalDate date) {
     return new Date(date);
   }
 
-  public static ConfidenceValue of(String value) {
+  public static ConfidenceValue<String> of(String value) {
     return new StringValue(value);
   }
 
-  public static ConfidenceValue of(boolean value) {
+  public static ConfidenceValue<Boolean> of(boolean value) {
     return new BooleanValue(value);
   }
 
-  public static ConfidenceValue.List ofStrings(java.util.List<String> values) {
-    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+  public static ConfidenceValue.List<String> ofStrings(
+      java.util.List<ConfidenceValue<String>> values) {
+    java.util.List<ConfidenceValue<String>> collect =
+        values.stream().map(v -> ConfidenceValue.of(v.asString())).collect(Collectors.toList());
+    return new List<>(collect);
   }
 
-  public static ConfidenceValue.List ofBooleans(java.util.List<Boolean> values) {
-    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+  public static ConfidenceValue.List<Boolean> ofBooleans(
+      java.util.List<ConfidenceValue<Boolean>> values) {
+    java.util.List<ConfidenceValue<Boolean>> collect =
+        values.stream().map(v -> ConfidenceValue.of(v.asBoolean())).collect(Collectors.toList());
+    return new List<>(collect);
   }
 
-  public static ConfidenceValue.List ofIntegers(java.util.List<java.lang.Integer> values) {
-    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+  public static ConfidenceValue.List<java.lang.Integer> ofIntegers(
+      java.util.List<ConfidenceValue<java.lang.Integer>> values) {
+    java.util.List<ConfidenceValue<java.lang.Integer>> collect =
+        values.stream().map(v -> ConfidenceValue.of(v.asInteger())).collect(Collectors.toList());
+    return new List<>(collect);
   }
 
-  public static ConfidenceValue.List ofDoubles(java.util.List<java.lang.Double> values) {
-    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+  public static ConfidenceValue.List<java.lang.Double> ofDoubles(
+      java.util.List<ConfidenceValue<java.lang.Double>> values) {
+    java.util.List<ConfidenceValue<java.lang.Double>> collect =
+        values.stream().map(v -> ConfidenceValue.of(v.asDouble())).collect(Collectors.toList());
+    return new List<>(collect);
   }
 
-  public static ConfidenceValue.List ofTimestamps(java.util.List<Instant> values) {
-    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+  public static ConfidenceValue.List<Instant> ofTimestamps(
+      java.util.List<ConfidenceValue<Instant>> values) {
+    java.util.List<ConfidenceValue<Instant>> collect =
+        values.stream().map(v -> ConfidenceValue.of(v.asInstant())).collect(Collectors.toList());
+    return new List<>(collect);
   }
 
-  public static ConfidenceValue.List ofDates(java.util.List<LocalDate> values) {
-    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+  public static ConfidenceValue.List<LocalDate> ofDates(
+      java.util.List<ConfidenceValue<LocalDate>> values) {
+    java.util.List<ConfidenceValue<LocalDate>> collect =
+        values.stream().map(v -> ConfidenceValue.of(v.asLocalDate())).collect(Collectors.toList());
+    return new List<>(collect);
   }
 
   public static Struct of(Map<String, ConfidenceValue> values) {
@@ -183,11 +202,10 @@ public abstract class ConfidenceValue {
 
   public abstract com.google.protobuf.Value toProto();
 
-  public static class StringValue extends ConfidenceValue {
-    private final String value;
+  public static class StringValue extends ConfidenceValue<String> {
 
     private StringValue(String value) {
-      this.value = value;
+      super.value = value;
     }
 
     @Override
@@ -197,25 +215,24 @@ public abstract class ConfidenceValue {
 
     @Override
     public String asString() {
-      return value;
+      return super.value;
     }
 
     @Override
     public com.google.protobuf.Value toProto() {
-      return com.google.protobuf.Value.newBuilder().setStringValue(value).build();
+      return com.google.protobuf.Value.newBuilder().setStringValue(super.value).build();
     }
 
     @Override
     public String toString() {
-      return value;
+      return super.value;
     }
   }
 
-  public static class BooleanValue extends ConfidenceValue {
-    private final boolean value;
+  public static class BooleanValue extends ConfidenceValue<Boolean> {
 
     private BooleanValue(boolean value) {
-      this.value = value;
+      super.value = value;
     }
 
     @Override
@@ -225,21 +242,21 @@ public abstract class ConfidenceValue {
 
     @Override
     public boolean asBoolean() {
-      return value;
+      return super.value;
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+      return String.valueOf(super.value);
     }
 
     @Override
     public com.google.protobuf.Value toProto() {
-      return com.google.protobuf.Value.newBuilder().setBoolValue(value).build();
+      return com.google.protobuf.Value.newBuilder().setBoolValue(super.value).build();
     }
   }
 
-  public static class Integer extends ConfidenceValue {
+  public static class Integer extends ConfidenceValue<java.lang.Integer> {
 
     private final int value;
 
@@ -268,12 +285,10 @@ public abstract class ConfidenceValue {
     }
   }
 
-  public static class Double extends ConfidenceValue {
-
-    private final double value;
+  public static class Double extends ConfidenceValue<java.lang.Double> {
 
     private Double(double value) {
-      this.value = value;
+      super.value = value;
     }
 
     @Override
@@ -283,26 +298,24 @@ public abstract class ConfidenceValue {
 
     @Override
     public double asDouble() {
-      return value;
+      return super.value;
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+      return String.valueOf(super.value);
     }
 
     @Override
     public com.google.protobuf.Value toProto() {
-      return com.google.protobuf.Value.newBuilder().setNumberValue(value).build();
+      return com.google.protobuf.Value.newBuilder().setNumberValue(super.value).build();
     }
   }
 
-  public static class Timestamp extends ConfidenceValue {
-
-    private final Instant value;
+  public static class Timestamp extends ConfidenceValue<Instant> {
 
     private Timestamp(Instant value) {
-      this.value = value;
+      super.value = value;
     }
 
     @Override
@@ -312,26 +325,24 @@ public abstract class ConfidenceValue {
 
     @Override
     public Instant asInstant() {
-      return value;
+      return super.value;
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+      return String.valueOf(super.value);
     }
 
     @Override
     public com.google.protobuf.Value toProto() {
-      return com.google.protobuf.Value.newBuilder().setStringValue(value.toString()).build();
+      return com.google.protobuf.Value.newBuilder().setStringValue(super.value.toString()).build();
     }
   }
 
-  public static class Date extends ConfidenceValue {
-
-    private final LocalDate value;
+  public static class Date extends ConfidenceValue<LocalDate> {
 
     private Date(LocalDate value) {
-      this.value = value;
+      super.value = value;
     }
 
     @Override
@@ -341,24 +352,24 @@ public abstract class ConfidenceValue {
 
     @Override
     public LocalDate asLocalDate() {
-      return value;
+      return super.value;
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+      return String.valueOf(super.value);
     }
 
     @Override
     public com.google.protobuf.Value toProto() {
-      return com.google.protobuf.Value.newBuilder().setStringValue(value.toString()).build();
+      return com.google.protobuf.Value.newBuilder().setStringValue(super.value.toString()).build();
     }
   }
 
-  public static class List extends ConfidenceValue {
-    private final ImmutableList<ConfidenceValue> values;
+  public static class List<T> extends ConfidenceValue {
+    private final ImmutableList<ConfidenceValue<T>> values;
 
-    private List(java.util.List<ConfidenceValue> values) {
+    private List(java.util.List<ConfidenceValue<T>> values) {
       this.values = ImmutableList.copyOf(values);
     }
 
@@ -369,7 +380,8 @@ public abstract class ConfidenceValue {
 
     @Override
     public java.util.List<ConfidenceValue> asList() {
-      return ImmutableList.copyOf(values);
+      ImmutableList<ConfidenceValue> confidenceValues = ImmutableList.copyOf(values);
+      return confidenceValues;
     }
 
     @Override
@@ -485,36 +497,6 @@ public abstract class ConfidenceValue {
 
       public Builder set(String key, boolean value) {
         return set(key, ConfidenceValue.of(value));
-      }
-
-      public Builder setIntegers(String key, java.util.List<java.lang.Integer> values) {
-        builder.put(key, ConfidenceValue.ofIntegers(values));
-        return this;
-      }
-
-      public Builder setDoubles(String key, java.util.List<java.lang.Double> values) {
-        builder.put(key, ConfidenceValue.ofDoubles(values));
-        return this;
-      }
-
-      public Builder setTimestamps(String key, java.util.List<Instant> values) {
-        builder.put(key, ConfidenceValue.ofTimestamps(values));
-        return this;
-      }
-
-      public Builder setDates(String key, java.util.List<LocalDate> values) {
-        builder.put(key, ConfidenceValue.ofDates(values));
-        return this;
-      }
-
-      public Builder setStrings(String key, java.util.List<String> values) {
-        builder.put(key, ConfidenceValue.ofStrings(values));
-        return this;
-      }
-
-      public Builder setBooleans(String key, java.util.List<java.lang.Boolean> values) {
-        builder.put(key, ConfidenceValue.ofBooleans(values));
-        return this;
       }
 
       public Builder set(String key, Builder value) {

--- a/src/main/java/com/spotify/confidence/ConfidenceValue.java
+++ b/src/main/java/com/spotify/confidence/ConfidenceValue.java
@@ -120,8 +120,8 @@ public abstract class ConfidenceValue {
     return new BooleanValue(value);
   }
 
-  public static List of(java.util.List<ConfidenceValue> values) {
-    return new List(values);
+  public static ConfidenceValue.List of(java.util.List<String> values) {
+    return new StringList(values);
   }
 
   public static Struct of(Map<String, ConfidenceValue> values) {
@@ -334,10 +334,16 @@ public abstract class ConfidenceValue {
     }
   }
 
+  public static class StringList extends List {
+    public StringList(java.util.List<String> values) {
+      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+    }
+  }
+
   public static class List extends ConfidenceValue {
     private final ImmutableList<ConfidenceValue> values;
 
-    public List(java.util.List<ConfidenceValue> values) {
+    private List(java.util.List<ConfidenceValue> values) {
       this.values = ImmutableList.copyOf(values);
     }
 

--- a/src/main/java/com/spotify/confidence/ConfidenceValue.java
+++ b/src/main/java/com/spotify/confidence/ConfidenceValue.java
@@ -7,6 +7,7 @@ import com.google.protobuf.ListValue;
 import com.google.protobuf.NullValue;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -493,7 +494,7 @@ public abstract class ConfidenceValue {
 
       private final ImmutableMap.Builder<String, ConfidenceValue> builder = ImmutableMap.builder();
 
-      public Builder set(String key, ConfidenceValue value) {
+      public Builder set(String key, ConfidenceValue.Struct value) {
         if (!value.isNull()) builder.put(key, value);
         return this;
       }
@@ -522,13 +523,43 @@ public abstract class ConfidenceValue {
         return set(key, ConfidenceValue.of(value));
       }
 
-      public Builder set(String key, List values) {
-        if (!values.isNull()) builder.put(key, values);
+      public Builder setIntegers(String key, java.util.List<java.lang.Integer> values) {
+        builder.put(key, ConfidenceValue.ofIntegers(values));
+        return this;
+      }
+
+      public Builder setDoubles(String key, java.util.List<java.lang.Double> values) {
+        builder.put(key, ConfidenceValue.ofDoubles(values));
+        return this;
+      }
+
+      public Builder setTimestamps(String key, java.util.List<Instant> values) {
+        builder.put(key, ConfidenceValue.ofTimestamps(values));
+        return this;
+      }
+
+      public Builder setDates(String key, java.util.List<LocalDate> values) {
+        builder.put(key, ConfidenceValue.ofDates(values));
+        return this;
+      }
+
+      public Builder setStrings(String key, java.util.List<String> values) {
+        builder.put(key, ConfidenceValue.ofStrings(values));
+        return this;
+      }
+
+      public Builder setBooleans(String key, java.util.List<java.lang.Boolean> values) {
+        builder.put(key, ConfidenceValue.ofBooleans(values));
         return this;
       }
 
       public Builder set(String key, Builder value) {
         return set(key, value.build());
+      }
+
+      private Builder set(String key, ConfidenceValue value) {
+        if (!value.isNull()) builder.put(key, value);
+        return this;
       }
 
       Struct build() {

--- a/src/main/java/com/spotify/confidence/ConfidenceValue.java
+++ b/src/main/java/com/spotify/confidence/ConfidenceValue.java
@@ -124,42 +124,42 @@ public abstract class ConfidenceValue<T> {
 
   public static ConfidenceValue.List<String> ofStrings(
       java.util.List<ConfidenceValue<String>> values) {
-    java.util.List<ConfidenceValue<String>> collect =
+    final java.util.List<ConfidenceValue<String>> collect =
         values.stream().map(v -> ConfidenceValue.of(v.asString())).collect(Collectors.toList());
     return new List<>(collect);
   }
 
   public static ConfidenceValue.List<Boolean> ofBooleans(
       java.util.List<ConfidenceValue<Boolean>> values) {
-    java.util.List<ConfidenceValue<Boolean>> collect =
+    final java.util.List<ConfidenceValue<Boolean>> collect =
         values.stream().map(v -> ConfidenceValue.of(v.asBoolean())).collect(Collectors.toList());
     return new List<>(collect);
   }
 
   public static ConfidenceValue.List<java.lang.Integer> ofIntegers(
       java.util.List<ConfidenceValue<java.lang.Integer>> values) {
-    java.util.List<ConfidenceValue<java.lang.Integer>> collect =
+    final java.util.List<ConfidenceValue<java.lang.Integer>> collect =
         values.stream().map(v -> ConfidenceValue.of(v.asInteger())).collect(Collectors.toList());
     return new List<>(collect);
   }
 
   public static ConfidenceValue.List<java.lang.Double> ofDoubles(
       java.util.List<ConfidenceValue<java.lang.Double>> values) {
-    java.util.List<ConfidenceValue<java.lang.Double>> collect =
+    final java.util.List<ConfidenceValue<java.lang.Double>> collect =
         values.stream().map(v -> ConfidenceValue.of(v.asDouble())).collect(Collectors.toList());
     return new List<>(collect);
   }
 
   public static ConfidenceValue.List<Instant> ofTimestamps(
       java.util.List<ConfidenceValue<Instant>> values) {
-    java.util.List<ConfidenceValue<Instant>> collect =
+    final java.util.List<ConfidenceValue<Instant>> collect =
         values.stream().map(v -> ConfidenceValue.of(v.asInstant())).collect(Collectors.toList());
     return new List<>(collect);
   }
 
   public static ConfidenceValue.List<LocalDate> ofDates(
       java.util.List<ConfidenceValue<LocalDate>> values) {
-    java.util.List<ConfidenceValue<LocalDate>> collect =
+    final java.util.List<ConfidenceValue<LocalDate>> collect =
         values.stream().map(v -> ConfidenceValue.of(v.asLocalDate())).collect(Collectors.toList());
     return new List<>(collect);
   }
@@ -258,10 +258,8 @@ public abstract class ConfidenceValue<T> {
 
   public static class Integer extends ConfidenceValue<java.lang.Integer> {
 
-    private final int value;
-
     private Integer(int value) {
-      this.value = value;
+      super.value = value;
     }
 
     @Override
@@ -271,17 +269,17 @@ public abstract class ConfidenceValue<T> {
 
     @Override
     public int asInteger() {
-      return value;
+      return super.value;
     }
 
     @Override
     public String toString() {
-      return String.valueOf(value);
+      return String.valueOf(super.value);
     }
 
     @Override
     public com.google.protobuf.Value toProto() {
-      return com.google.protobuf.Value.newBuilder().setNumberValue(value).build();
+      return com.google.protobuf.Value.newBuilder().setNumberValue(super.value).build();
     }
   }
 
@@ -366,11 +364,10 @@ public abstract class ConfidenceValue<T> {
     }
   }
 
-  public static class List<T> extends ConfidenceValue {
-    private final ImmutableList<ConfidenceValue<T>> values;
+  public static class List<T> extends ConfidenceValue<ImmutableList<ConfidenceValue<T>>> {
 
     private List(java.util.List<ConfidenceValue<T>> values) {
-      this.values = ImmutableList.copyOf(values);
+      super.value = ImmutableList.copyOf(values);
     }
 
     @Override
@@ -380,13 +377,13 @@ public abstract class ConfidenceValue<T> {
 
     @Override
     public java.util.List<ConfidenceValue> asList() {
-      ImmutableList<ConfidenceValue> confidenceValues = ImmutableList.copyOf(values);
+      final ImmutableList<ConfidenceValue> confidenceValues = ImmutableList.copyOf(super.value);
       return confidenceValues;
     }
 
     @Override
     public String toString() {
-      return "[" + values + "]";
+      return "[" + super.value + "]";
     }
 
     @Override
@@ -394,7 +391,7 @@ public abstract class ConfidenceValue<T> {
       final ListValue value =
           ListValue.newBuilder()
               .addAllValues(
-                  values.stream().map(ConfidenceValue::toProto).collect(Collectors.toList()))
+                  super.value.stream().map(ConfidenceValue::toProto).collect(Collectors.toList()))
               .build();
       return com.google.protobuf.Value.newBuilder().setListValue(value).build();
     }
@@ -407,12 +404,11 @@ public abstract class ConfidenceValue<T> {
     }
   }
 
-  public static class Struct extends ConfidenceValue {
+  public static class Struct extends ConfidenceValue<ImmutableMap<String, ConfidenceValue>> {
     public static final Struct EMPTY = new Struct(ImmutableMap.of());
-    private final ImmutableMap<String, ConfidenceValue> values;
 
     protected Struct(Map<String, ConfidenceValue> values) {
-      this.values = ImmutableMap.copyOf(values);
+      super.value = ImmutableMap.copyOf(values);
     }
 
     @Override
@@ -422,7 +418,7 @@ public abstract class ConfidenceValue<T> {
 
     @Override
     public Struct asStruct() {
-      return new Struct(values);
+      return new Struct(super.value);
     }
 
     public ConfidenceValue get(String... path) {
@@ -432,14 +428,14 @@ public abstract class ConfidenceValue<T> {
           // todo better error
           throw new IllegalStateException();
         }
-        value = values.getOrDefault(path[i], NULL_VALUE);
+        value = super.value.getOrDefault(path[i], NULL_VALUE);
       }
       return value;
     }
 
     @Override
     public String toString() {
-      return values.toString();
+      return super.value.toString();
     }
 
     public static Builder builder() {
@@ -449,7 +445,7 @@ public abstract class ConfidenceValue<T> {
     @Override
     public com.google.protobuf.Value toProto() {
       final com.google.protobuf.Struct.Builder builder = com.google.protobuf.Struct.newBuilder();
-      values.forEach((key, value) -> builder.putFields(key, value.toProto()));
+      super.value.forEach((key, value) -> builder.putFields(key, value.toProto()));
       return com.google.protobuf.Value.newBuilder().setStructValue(builder).build();
     }
 
@@ -458,11 +454,11 @@ public abstract class ConfidenceValue<T> {
     }
 
     public Map<String, ConfidenceValue> asMap() {
-      return values;
+      return super.value;
     }
 
     public Map<String, com.google.protobuf.Value> asProtoMap() {
-      return values.entrySet().stream()
+      return super.value.entrySet().stream()
           .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toProto()));
     }
 

--- a/src/main/java/com/spotify/confidence/ConfidenceValue.java
+++ b/src/main/java/com/spotify/confidence/ConfidenceValue.java
@@ -522,6 +522,11 @@ public abstract class ConfidenceValue {
         return set(key, ConfidenceValue.of(value));
       }
 
+      public Builder set(String key, List values) {
+        if (!values.isNull()) builder.put(key, values);
+        return this;
+      }
+
       public Builder set(String key, Builder value) {
         return set(key, value.build());
       }

--- a/src/main/java/com/spotify/confidence/ConfidenceValue.java
+++ b/src/main/java/com/spotify/confidence/ConfidenceValue.java
@@ -128,6 +128,22 @@ public abstract class ConfidenceValue {
     return new BooleanList(values);
   }
 
+  public static ConfidenceValue.List ofIntegers(java.util.List<java.lang.Integer> values) {
+    return new IntegerList(values);
+  }
+
+  public static ConfidenceValue.List ofDoubles(java.util.List<java.lang.Double> values) {
+    return new DoubleList(values);
+  }
+
+  public static ConfidenceValue.List ofTimestamps(java.util.List<Instant> values) {
+    return new TimestampList(values);
+  }
+
+  public static ConfidenceValue.List ofDates(java.util.List<LocalDate> values) {
+    return new DateList(values);
+  }
+
   public static Struct of(Map<String, ConfidenceValue> values) {
     return new Struct(values);
   }
@@ -346,6 +362,30 @@ public abstract class ConfidenceValue {
 
   public static class BooleanList extends List {
     public BooleanList(java.util.List<Boolean> values) {
+      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+    }
+  }
+
+  public static class IntegerList extends List {
+    public IntegerList(java.util.List<java.lang.Integer> values) {
+      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+    }
+  }
+
+  public static class DoubleList extends List {
+    public DoubleList(java.util.List<java.lang.Double> values) {
+      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+    }
+  }
+
+  public static class TimestampList extends List {
+    public TimestampList(java.util.List<Instant> values) {
+      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+    }
+  }
+
+  public static class DateList extends List {
+    public DateList(java.util.List<LocalDate> values) {
       super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
     }
   }

--- a/src/main/java/com/spotify/confidence/ConfidenceValue.java
+++ b/src/main/java/com/spotify/confidence/ConfidenceValue.java
@@ -120,8 +120,12 @@ public abstract class ConfidenceValue {
     return new BooleanValue(value);
   }
 
-  public static ConfidenceValue.List of(java.util.List<String> values) {
+  public static ConfidenceValue.List ofStrings(java.util.List<String> values) {
     return new StringList(values);
+  }
+
+  public static ConfidenceValue.List ofBooleans(java.util.List<Boolean> values) {
+    return new BooleanList(values);
   }
 
   public static Struct of(Map<String, ConfidenceValue> values) {
@@ -336,6 +340,12 @@ public abstract class ConfidenceValue {
 
   public static class StringList extends List {
     public StringList(java.util.List<String> values) {
+      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+    }
+  }
+
+  public static class BooleanList extends List {
+    public BooleanList(java.util.List<Boolean> values) {
       super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
     }
   }

--- a/src/main/java/com/spotify/confidence/ConfidenceValue.java
+++ b/src/main/java/com/spotify/confidence/ConfidenceValue.java
@@ -122,27 +122,27 @@ public abstract class ConfidenceValue {
   }
 
   public static ConfidenceValue.List ofStrings(java.util.List<String> values) {
-    return new StringList(values);
+    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
   }
 
   public static ConfidenceValue.List ofBooleans(java.util.List<Boolean> values) {
-    return new BooleanList(values);
+    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
   }
 
   public static ConfidenceValue.List ofIntegers(java.util.List<java.lang.Integer> values) {
-    return new IntegerList(values);
+    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
   }
 
   public static ConfidenceValue.List ofDoubles(java.util.List<java.lang.Double> values) {
-    return new DoubleList(values);
+    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
   }
 
   public static ConfidenceValue.List ofTimestamps(java.util.List<Instant> values) {
-    return new TimestampList(values);
+    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
   }
 
   public static ConfidenceValue.List ofDates(java.util.List<LocalDate> values) {
-    return new DateList(values);
+    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
   }
 
   public static Struct of(Map<String, ConfidenceValue> values) {
@@ -355,42 +355,6 @@ public abstract class ConfidenceValue {
     }
   }
 
-  public static class StringList extends List {
-    public StringList(java.util.List<String> values) {
-      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
-    }
-  }
-
-  public static class BooleanList extends List {
-    public BooleanList(java.util.List<Boolean> values) {
-      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
-    }
-  }
-
-  public static class IntegerList extends List {
-    public IntegerList(java.util.List<java.lang.Integer> values) {
-      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
-    }
-  }
-
-  public static class DoubleList extends List {
-    public DoubleList(java.util.List<java.lang.Double> values) {
-      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
-    }
-  }
-
-  public static class TimestampList extends List {
-    public TimestampList(java.util.List<Instant> values) {
-      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
-    }
-  }
-
-  public static class DateList extends List {
-    public DateList(java.util.List<LocalDate> values) {
-      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
-    }
-  }
-
   public static class List extends ConfidenceValue {
     private final ImmutableList<ConfidenceValue> values;
 
@@ -494,7 +458,7 @@ public abstract class ConfidenceValue {
 
       private final ImmutableMap.Builder<String, ConfidenceValue> builder = ImmutableMap.builder();
 
-      public Builder set(String key, ConfidenceValue.Struct value) {
+      public Builder set(String key, ConfidenceValue value) {
         if (!value.isNull()) builder.put(key, value);
         return this;
       }
@@ -555,11 +519,6 @@ public abstract class ConfidenceValue {
 
       public Builder set(String key, Builder value) {
         return set(key, value.build());
-      }
-
-      private Builder set(String key, ConfidenceValue value) {
-        if (!value.isNull()) builder.put(key, value);
-        return this;
       }
 
       Struct build() {

--- a/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
+++ b/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
@@ -3,6 +3,7 @@ package com.spotify.confidence;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ListValue;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -140,9 +141,7 @@ class ConfidenceValueTest {
 
   @Test
   public void testListValue() {
-    final ConfidenceValue.List listValue =
-        new ConfidenceValue.List(
-            Arrays.asList(ConfidenceValue.of("item1"), ConfidenceValue.of("item2")));
+    final ConfidenceValue.List listValue = ConfidenceValue.of(ImmutableList.of("item1", "item2"));
     assertEquals(
         listValue.toProto(),
         com.google.protobuf.Value.newBuilder()
@@ -251,10 +250,7 @@ class ConfidenceValueTest {
     map.put("timestamp", ConfidenceValue.of(instant));
     map.put("date", ConfidenceValue.of(localDate));
     map.put("boolean", ConfidenceValue.of(false));
-    map.put(
-        "list",
-        ConfidenceValue.of(
-            java.util.List.of(ConfidenceValue.of("item1"), ConfidenceValue.of("item2"))));
+    map.put("list", ConfidenceValue.of(java.util.List.of("item1", "item2")));
     map.put("struct", ConfidenceValue.of(map));
     final ConfidenceValue.Struct struct = ConfidenceValue.of(map);
     assertEquals(

--- a/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
+++ b/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
@@ -375,6 +375,8 @@ class ConfidenceValueTest {
   public void testStructBuilderSetValues() {
     final Instant instant = Instant.parse("2007-12-03T10:15:30.00Z");
     final LocalDate date = LocalDate.parse("2007-12-03");
+    ConfidenceValue.List stringList =
+        ConfidenceValue.ofStrings(ImmutableList.of("string1", "strign2"));
     final ConfidenceValue.Struct struct =
         ConfidenceValue.Struct.builder()
             .set("key1", "value")
@@ -383,6 +385,7 @@ class ConfidenceValueTest {
             .set("key4", 42.0)
             .set("key5", instant)
             .set("key6", date)
+            .set("key7", stringList)
             .build();
     assertEquals(ConfidenceValue.of("value"), struct.get("key1"));
     assertEquals(ConfidenceValue.of(42), struct.get("key2"));
@@ -390,6 +393,7 @@ class ConfidenceValueTest {
     assertEquals(ConfidenceValue.of(42.0), struct.get("key4"));
     assertEquals(ConfidenceValue.of(instant), struct.get("key5"));
     assertEquals(ConfidenceValue.of(date), struct.get("key6"));
+    assertEquals(stringList, struct.get("key7"));
   }
 
   @Test

--- a/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
+++ b/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
@@ -375,7 +375,7 @@ class ConfidenceValueTest {
   public void testStructBuilderSetValues() {
     final Instant instant = Instant.parse("2007-12-03T10:15:30.00Z");
     final LocalDate date = LocalDate.parse("2007-12-03");
-    List<String> stringList = List.of("string1", "string2");
+    final List<String> stringList = List.of("string1", "string2");
     final ConfidenceValue.Struct struct =
         ConfidenceValue.Struct.builder()
             .set("key1", "value")

--- a/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
+++ b/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
@@ -143,8 +143,9 @@ class ConfidenceValueTest {
 
   @Test
   public void testStringListValue() {
-    final ConfidenceValue.List listValue =
-        ConfidenceValue.ofStrings(ImmutableList.of("item1", "item2"));
+    final ConfidenceValue.List<String> listValue =
+        ConfidenceValue.ofStrings(
+            ImmutableList.of(ConfidenceValue.of("item1"), ConfidenceValue.of("item2")));
     assertTrue(listValue.isList());
     assertEquals(
         ImmutableList.of(ConfidenceValue.of("item1"), ConfidenceValue.of("item2")),
@@ -163,7 +164,8 @@ class ConfidenceValueTest {
 
   @Test
   public void testIntegerListValue() {
-    final ConfidenceValue.List listValue = ConfidenceValue.ofIntegers(ImmutableList.of(3, 5));
+    final ConfidenceValue.List<Integer> listValue =
+        ConfidenceValue.ofIntegers(ImmutableList.of(ConfidenceValue.of(3), ConfidenceValue.of(5)));
     assertEquals(
         listValue.toProto(),
         com.google.protobuf.Value.newBuilder()
@@ -178,7 +180,9 @@ class ConfidenceValueTest {
 
   @Test
   public void testDoubleListValue() {
-    final ConfidenceValue.List listValue = ConfidenceValue.ofDoubles(ImmutableList.of(3.1, 4.2));
+    final ConfidenceValue.List<Double> listValue =
+        ConfidenceValue.ofDoubles(
+            ImmutableList.of(ConfidenceValue.of(3.1), ConfidenceValue.of(4.2)));
     assertEquals(
         listValue.toProto(),
         com.google.protobuf.Value.newBuilder()
@@ -196,8 +200,9 @@ class ConfidenceValueTest {
     final Instant instant1 = Instant.parse("2007-12-03T10:15:30.00Z");
     final Instant instant2 = Instant.parse("2007-12-03T10:15:31.00Z");
 
-    final ConfidenceValue.List listValue =
-        ConfidenceValue.ofTimestamps(ImmutableList.of(instant1, instant2));
+    final ConfidenceValue.List<Instant> listValue =
+        ConfidenceValue.ofTimestamps(
+            ImmutableList.of(ConfidenceValue.of(instant1), ConfidenceValue.of(instant2)));
     assertEquals(
         listValue.toProto(),
         com.google.protobuf.Value.newBuilder()
@@ -215,7 +220,9 @@ class ConfidenceValueTest {
     final LocalDate date1 = LocalDate.parse("2007-12-03");
     final LocalDate date2 = LocalDate.parse("2007-12-04");
 
-    final ConfidenceValue.List listValue = ConfidenceValue.ofDates(ImmutableList.of(date1, date2));
+    final ConfidenceValue.List<LocalDate> listValue =
+        ConfidenceValue.ofDates(
+            ImmutableList.of(ConfidenceValue.of(date1), ConfidenceValue.of(date2)));
     assertEquals(
         listValue.toProto(),
         com.google.protobuf.Value.newBuilder()
@@ -230,8 +237,9 @@ class ConfidenceValueTest {
 
   @Test
   public void testBooleanListValue() {
-    final ConfidenceValue.List listValue =
-        ConfidenceValue.ofBooleans(ImmutableList.of(true, false));
+    final ConfidenceValue.List<Boolean> listValue =
+        ConfidenceValue.ofBooleans(
+            ImmutableList.of(ConfidenceValue.of(true), ConfidenceValue.of(false)));
     assertEquals(
         listValue.toProto(),
         com.google.protobuf.Value.newBuilder()
@@ -288,13 +296,11 @@ class ConfidenceValueTest {
                     .map(ConfidenceValue::toProto)
                     .collect(Collectors.toList()))
             .build();
-    final ConfidenceValue.List listValue = ConfidenceValue.List.fromProto(protoListValue);
+    final List<ConfidenceValue> listValue = ConfidenceValue.List.fromProto(protoListValue).asList();
     assertEquals(
-        listValue.asList().get(0).asString(),
-        protoListValue.getValuesList().get(0).getStringValue());
+        listValue.get(0).asString(), protoListValue.getValuesList().get(0).getStringValue());
     assertEquals(
-        listValue.asList().get(1).asString(),
-        protoListValue.getValuesList().get(1).getStringValue());
+        listValue.get(1).asString(), protoListValue.getValuesList().get(1).getStringValue());
   }
 
   @Test
@@ -339,8 +345,14 @@ class ConfidenceValueTest {
     map.put("timestamp", ConfidenceValue.of(instant));
     map.put("date", ConfidenceValue.of(localDate));
     map.put("boolean", ConfidenceValue.of(false));
-    map.put("list", ConfidenceValue.ofStrings(List.of("item1", "item2")));
-    map.put("timestamp_list", ConfidenceValue.ofTimestamps(List.of(instant, instant)));
+    map.put(
+        "list",
+        ConfidenceValue.ofStrings(
+            List.of(ConfidenceValue.of("item1"), ConfidenceValue.of("item2"))));
+    map.put(
+        "timestamp_list",
+        ConfidenceValue.ofTimestamps(
+            List.of(ConfidenceValue.of(instant), ConfidenceValue.of(instant))));
     map.put("struct", ConfidenceValue.of(map));
     final ConfidenceValue.Struct struct = ConfidenceValue.of(map);
     assertEquals(
@@ -375,7 +387,8 @@ class ConfidenceValueTest {
   public void testStructBuilderSetValues() {
     final Instant instant = Instant.parse("2007-12-03T10:15:30.00Z");
     final LocalDate date = LocalDate.parse("2007-12-03");
-    final List<String> stringList = List.of("string1", "string2");
+    final ImmutableList<ConfidenceValue<String>> stringList =
+        ImmutableList.of(ConfidenceValue.of("string1"), ConfidenceValue.of("string2"));
     final ConfidenceValue.Struct struct =
         ConfidenceValue.Struct.builder()
             .set("key1", "value")
@@ -384,7 +397,7 @@ class ConfidenceValueTest {
             .set("key4", 42.0)
             .set("key5", instant)
             .set("key6", date)
-            .setStrings("key7", ImmutableList.of("string1", "string2"))
+            .set("key7", ConfidenceValue.ofStrings(stringList))
             .build();
     assertEquals(ConfidenceValue.of("value"), struct.get("key1"));
     assertEquals(ConfidenceValue.of(42), struct.get("key2"));

--- a/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
+++ b/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
@@ -375,8 +375,7 @@ class ConfidenceValueTest {
   public void testStructBuilderSetValues() {
     final Instant instant = Instant.parse("2007-12-03T10:15:30.00Z");
     final LocalDate date = LocalDate.parse("2007-12-03");
-    ConfidenceValue.List stringList =
-        ConfidenceValue.ofStrings(ImmutableList.of("string1", "strign2"));
+    List<String> stringList = List.of("string1", "string2");
     final ConfidenceValue.Struct struct =
         ConfidenceValue.Struct.builder()
             .set("key1", "value")
@@ -385,7 +384,7 @@ class ConfidenceValueTest {
             .set("key4", 42.0)
             .set("key5", instant)
             .set("key6", date)
-            .set("key7", stringList)
+            .setStrings("key7", ImmutableList.of("string1", "string2"))
             .build();
     assertEquals(ConfidenceValue.of("value"), struct.get("key1"));
     assertEquals(ConfidenceValue.of(42), struct.get("key2"));
@@ -393,7 +392,7 @@ class ConfidenceValueTest {
     assertEquals(ConfidenceValue.of(42.0), struct.get("key4"));
     assertEquals(ConfidenceValue.of(instant), struct.get("key5"));
     assertEquals(ConfidenceValue.of(date), struct.get("key6"));
-    assertEquals(stringList, struct.get("key7"));
+    assertEquals(ConfidenceValue.ofStrings(stringList), struct.get("key7"));
   }
 
   @Test

--- a/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
+++ b/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
@@ -7,8 +7,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ListValue;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -140,16 +140,32 @@ class ConfidenceValueTest {
   }
 
   @Test
-  public void testListValue() {
-    final ConfidenceValue.List listValue = ConfidenceValue.of(ImmutableList.of("item1", "item2"));
+  public void testStringListValue() {
+    final ConfidenceValue.List listValue =
+        ConfidenceValue.ofStrings(ImmutableList.of("item1", "item2"));
     assertEquals(
         listValue.toProto(),
         com.google.protobuf.Value.newBuilder()
             .setListValue(
                 ListValue.newBuilder()
                     .addAllValues(
-                        Arrays.asList(ConfidenceValue.of("item1"), ConfidenceValue.of("item2"))
-                            .stream()
+                        Stream.of(ConfidenceValue.of("item1"), ConfidenceValue.of("item2"))
+                            .map(ConfidenceValue::toProto)
+                            .collect(Collectors.toList())))
+            .build());
+  }
+
+  @Test
+  public void testBooleanListValue() {
+    final ConfidenceValue.List listValue =
+        ConfidenceValue.ofBooleans(ImmutableList.of(true, false));
+    assertEquals(
+        listValue.toProto(),
+        com.google.protobuf.Value.newBuilder()
+            .setListValue(
+                ListValue.newBuilder()
+                    .addAllValues(
+                        Stream.of(ConfidenceValue.of(true), ConfidenceValue.of(false))
                             .map(ConfidenceValue::toProto)
                             .collect(Collectors.toList())))
             .build());
@@ -250,7 +266,7 @@ class ConfidenceValueTest {
     map.put("timestamp", ConfidenceValue.of(instant));
     map.put("date", ConfidenceValue.of(localDate));
     map.put("boolean", ConfidenceValue.of(false));
-    map.put("list", ConfidenceValue.of(java.util.List.of("item1", "item2")));
+    map.put("list", ConfidenceValue.ofStrings(List.of("item1", "item2")));
     map.put("struct", ConfidenceValue.of(map));
     final ConfidenceValue.Struct struct = ConfidenceValue.of(map);
     assertEquals(


### PR DESCRIPTION
Usage:
```
ConfidenceValue.ofIntegers(ImmutableList.of(ConfidenceValue.of(3), ConfidenceValue.of(5)));
```