### PR TITLE
feat: Limit ConfidenceValue.List to supported types (java types)

### DIFF
--- a/src/main/java/com/spotify/confidence/ConfidenceValue.java
+++ b/src/main/java/com/spotify/confidence/ConfidenceValue.java
@@ -120,8 +120,8 @@ public abstract class ConfidenceValue {
     return new BooleanValue(value);
   }
 
-  public static List of(java.util.List<ConfidenceValue> values) {
-    return new List(values);
+  public static ConfidenceValue.List of(java.util.List<String> values) {
+    return new StringList(values);
   }
 
   public static Struct of(Map<String, ConfidenceValue> values) {
@@ -334,10 +334,16 @@ public abstract class ConfidenceValue {
     }
   }
 
+  public static class StringList extends List {
+    public StringList(java.util.List<String> values) {
+      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+    }
+  }
+
   public static class List extends ConfidenceValue {
     private final ImmutableList<ConfidenceValue> values;
 
-    public List(java.util.List<ConfidenceValue> values) {
+    private List(java.util.List<ConfidenceValue> values) {
       this.values = ImmutableList.copyOf(values);
     }
 

--- a/src/main/java/com/spotify/confidence/ConfidenceValue.java
+++ b/src/main/java/com/spotify/confidence/ConfidenceValue.java
@@ -7,6 +7,7 @@ import com.google.protobuf.ListValue;
 import com.google.protobuf.NullValue;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -493,7 +494,7 @@ public abstract class ConfidenceValue {
 
       private final ImmutableMap.Builder<String, ConfidenceValue> builder = ImmutableMap.builder();
 
-      public Builder set(String key, ConfidenceValue value) {
+      public Builder set(String key, ConfidenceValue.Struct value) {
         if (!value.isNull()) builder.put(key, value);
         return this;
       }
@@ -522,13 +523,43 @@ public abstract class ConfidenceValue {
         return set(key, ConfidenceValue.of(value));
       }
 
-      public Builder set(String key, List values) {
-        if (!values.isNull()) builder.put(key, values);
+      public Builder setIntegers(String key, java.util.List<java.lang.Integer> values) {
+        builder.put(key, ConfidenceValue.ofIntegers(values));
+        return this;
+      }
+
+      public Builder setDoubles(String key, java.util.List<java.lang.Double> values) {
+        builder.put(key, ConfidenceValue.ofDoubles(values));
+        return this;
+      }
+
+      public Builder setTimestamps(String key, java.util.List<Instant> values) {
+        builder.put(key, ConfidenceValue.ofTimestamps(values));
+        return this;
+      }
+
+      public Builder setDates(String key, java.util.List<LocalDate> values) {
+        builder.put(key, ConfidenceValue.ofDates(values));
+        return this;
+      }
+
+      public Builder setStrings(String key, java.util.List<String> values) {
+        builder.put(key, ConfidenceValue.ofStrings(values));
+        return this;
+      }
+
+      public Builder setBooleans(String key, java.util.List<java.lang.Boolean> values) {
+        builder.put(key, ConfidenceValue.ofBooleans(values));
         return this;
       }
 
       public Builder set(String key, Builder value) {
         return set(key, value.build());
+      }
+
+      private Builder set(String key, ConfidenceValue value) {
+        if (!value.isNull()) builder.put(key, value);
+        return this;
       }
 
       Struct build() {

--- a/src/main/java/com/spotify/confidence/ConfidenceValue.java
+++ b/src/main/java/com/spotify/confidence/ConfidenceValue.java
@@ -522,6 +522,11 @@ public abstract class ConfidenceValue {
         return set(key, ConfidenceValue.of(value));
       }
 
+      public Builder set(String key, List values) {
+        if (!values.isNull()) builder.put(key, values);
+        return this;
+      }
+
       public Builder set(String key, Builder value) {
         return set(key, value.build());
       }

--- a/src/main/java/com/spotify/confidence/ConfidenceValue.java
+++ b/src/main/java/com/spotify/confidence/ConfidenceValue.java
@@ -128,6 +128,22 @@ public abstract class ConfidenceValue {
     return new BooleanList(values);
   }
 
+  public static ConfidenceValue.List ofIntegers(java.util.List<java.lang.Integer> values) {
+    return new IntegerList(values);
+  }
+
+  public static ConfidenceValue.List ofDoubles(java.util.List<java.lang.Double> values) {
+    return new DoubleList(values);
+  }
+
+  public static ConfidenceValue.List ofTimestamps(java.util.List<Instant> values) {
+    return new TimestampList(values);
+  }
+
+  public static ConfidenceValue.List ofDates(java.util.List<LocalDate> values) {
+    return new DateList(values);
+  }
+
   public static Struct of(Map<String, ConfidenceValue> values) {
     return new Struct(values);
   }
@@ -346,6 +362,30 @@ public abstract class ConfidenceValue {
 
   public static class BooleanList extends List {
     public BooleanList(java.util.List<Boolean> values) {
+      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+    }
+  }
+
+  public static class IntegerList extends List {
+    public IntegerList(java.util.List<java.lang.Integer> values) {
+      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+    }
+  }
+
+  public static class DoubleList extends List {
+    public DoubleList(java.util.List<java.lang.Double> values) {
+      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+    }
+  }
+
+  public static class TimestampList extends List {
+    public TimestampList(java.util.List<Instant> values) {
+      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+    }
+  }
+
+  public static class DateList extends List {
+    public DateList(java.util.List<LocalDate> values) {
       super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
     }
   }

--- a/src/main/java/com/spotify/confidence/ConfidenceValue.java
+++ b/src/main/java/com/spotify/confidence/ConfidenceValue.java
@@ -120,8 +120,12 @@ public abstract class ConfidenceValue {
     return new BooleanValue(value);
   }
 
-  public static ConfidenceValue.List of(java.util.List<String> values) {
+  public static ConfidenceValue.List ofStrings(java.util.List<String> values) {
     return new StringList(values);
+  }
+
+  public static ConfidenceValue.List ofBooleans(java.util.List<Boolean> values) {
+    return new BooleanList(values);
   }
 
   public static Struct of(Map<String, ConfidenceValue> values) {
@@ -336,6 +340,12 @@ public abstract class ConfidenceValue {
 
   public static class StringList extends List {
     public StringList(java.util.List<String> values) {
+      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
+    }
+  }
+
+  public static class BooleanList extends List {
+    public BooleanList(java.util.List<Boolean> values) {
       super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
     }
   }

--- a/src/main/java/com/spotify/confidence/ConfidenceValue.java
+++ b/src/main/java/com/spotify/confidence/ConfidenceValue.java
@@ -122,27 +122,27 @@ public abstract class ConfidenceValue {
   }
 
   public static ConfidenceValue.List ofStrings(java.util.List<String> values) {
-    return new StringList(values);
+    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
   }
 
   public static ConfidenceValue.List ofBooleans(java.util.List<Boolean> values) {
-    return new BooleanList(values);
+    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
   }
 
   public static ConfidenceValue.List ofIntegers(java.util.List<java.lang.Integer> values) {
-    return new IntegerList(values);
+    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
   }
 
   public static ConfidenceValue.List ofDoubles(java.util.List<java.lang.Double> values) {
-    return new DoubleList(values);
+    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
   }
 
   public static ConfidenceValue.List ofTimestamps(java.util.List<Instant> values) {
-    return new TimestampList(values);
+    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
   }
 
   public static ConfidenceValue.List ofDates(java.util.List<LocalDate> values) {
-    return new DateList(values);
+    return new List(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
   }
 
   public static Struct of(Map<String, ConfidenceValue> values) {
@@ -355,42 +355,6 @@ public abstract class ConfidenceValue {
     }
   }
 
-  public static class StringList extends List {
-    public StringList(java.util.List<String> values) {
-      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
-    }
-  }
-
-  public static class BooleanList extends List {
-    public BooleanList(java.util.List<Boolean> values) {
-      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
-    }
-  }
-
-  public static class IntegerList extends List {
-    public IntegerList(java.util.List<java.lang.Integer> values) {
-      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
-    }
-  }
-
-  public static class DoubleList extends List {
-    public DoubleList(java.util.List<java.lang.Double> values) {
-      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
-    }
-  }
-
-  public static class TimestampList extends List {
-    public TimestampList(java.util.List<Instant> values) {
-      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
-    }
-  }
-
-  public static class DateList extends List {
-    public DateList(java.util.List<LocalDate> values) {
-      super(values.stream().map(ConfidenceValue::of).collect(Collectors.toList()));
-    }
-  }
-
   public static class List extends ConfidenceValue {
     private final ImmutableList<ConfidenceValue> values;
 
@@ -494,7 +458,7 @@ public abstract class ConfidenceValue {
 
       private final ImmutableMap.Builder<String, ConfidenceValue> builder = ImmutableMap.builder();
 
-      public Builder set(String key, ConfidenceValue.Struct value) {
+      public Builder set(String key, ConfidenceValue value) {
         if (!value.isNull()) builder.put(key, value);
         return this;
       }
@@ -555,11 +519,6 @@ public abstract class ConfidenceValue {
 
       public Builder set(String key, Builder value) {
         return set(key, value.build());
-      }
-
-      private Builder set(String key, ConfidenceValue value) {
-        if (!value.isNull()) builder.put(key, value);
-        return this;
       }
 
       Struct build() {

--- a/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
+++ b/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
@@ -3,6 +3,7 @@ package com.spotify.confidence;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ListValue;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -140,9 +141,7 @@ class ConfidenceValueTest {
 
   @Test
   public void testListValue() {
-    final ConfidenceValue.List listValue =
-        new ConfidenceValue.List(
-            Arrays.asList(ConfidenceValue.of("item1"), ConfidenceValue.of("item2")));
+    final ConfidenceValue.List listValue = ConfidenceValue.of(ImmutableList.of("item1", "item2"));
     assertEquals(
         listValue.toProto(),
         com.google.protobuf.Value.newBuilder()
@@ -251,10 +250,7 @@ class ConfidenceValueTest {
     map.put("timestamp", ConfidenceValue.of(instant));
     map.put("date", ConfidenceValue.of(localDate));
     map.put("boolean", ConfidenceValue.of(false));
-    map.put(
-        "list",
-        ConfidenceValue.of(
-            java.util.List.of(ConfidenceValue.of("item1"), ConfidenceValue.of("item2"))));
+    map.put("list", ConfidenceValue.of(java.util.List.of("item1", "item2")));
     map.put("struct", ConfidenceValue.of(map));
     final ConfidenceValue.Struct struct = ConfidenceValue.of(map);
     assertEquals(

--- a/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
+++ b/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
@@ -375,6 +375,8 @@ class ConfidenceValueTest {
   public void testStructBuilderSetValues() {
     final Instant instant = Instant.parse("2007-12-03T10:15:30.00Z");
     final LocalDate date = LocalDate.parse("2007-12-03");
+    ConfidenceValue.List stringList =
+        ConfidenceValue.ofStrings(ImmutableList.of("string1", "strign2"));
     final ConfidenceValue.Struct struct =
         ConfidenceValue.Struct.builder()
             .set("key1", "value")
@@ -383,6 +385,7 @@ class ConfidenceValueTest {
             .set("key4", 42.0)
             .set("key5", instant)
             .set("key6", date)
+            .set("key7", stringList)
             .build();
     assertEquals(ConfidenceValue.of("value"), struct.get("key1"));
     assertEquals(ConfidenceValue.of(42), struct.get("key2"));
@@ -390,6 +393,7 @@ class ConfidenceValueTest {
     assertEquals(ConfidenceValue.of(42.0), struct.get("key4"));
     assertEquals(ConfidenceValue.of(instant), struct.get("key5"));
     assertEquals(ConfidenceValue.of(date), struct.get("key6"));
+    assertEquals(stringList, struct.get("key7"));
   }
 
   @Test

--- a/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
+++ b/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
@@ -375,7 +375,7 @@ class ConfidenceValueTest {
   public void testStructBuilderSetValues() {
     final Instant instant = Instant.parse("2007-12-03T10:15:30.00Z");
     final LocalDate date = LocalDate.parse("2007-12-03");
-    List<String> stringList = List.of("string1", "string2");
+    final List<String> stringList = List.of("string1", "string2");
     final ConfidenceValue.Struct struct =
         ConfidenceValue.Struct.builder()
             .set("key1", "value")

--- a/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
+++ b/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
@@ -375,8 +375,7 @@ class ConfidenceValueTest {
   public void testStructBuilderSetValues() {
     final Instant instant = Instant.parse("2007-12-03T10:15:30.00Z");
     final LocalDate date = LocalDate.parse("2007-12-03");
-    ConfidenceValue.List stringList =
-        ConfidenceValue.ofStrings(ImmutableList.of("string1", "strign2"));
+    List<String> stringList = List.of("string1", "string2");
     final ConfidenceValue.Struct struct =
         ConfidenceValue.Struct.builder()
             .set("key1", "value")
@@ -385,7 +384,7 @@ class ConfidenceValueTest {
             .set("key4", 42.0)
             .set("key5", instant)
             .set("key6", date)
-            .set("key7", stringList)
+            .setStrings("key7", ImmutableList.of("string1", "string2"))
             .build();
     assertEquals(ConfidenceValue.of("value"), struct.get("key1"));
     assertEquals(ConfidenceValue.of(42), struct.get("key2"));
@@ -393,7 +392,7 @@ class ConfidenceValueTest {
     assertEquals(ConfidenceValue.of(42.0), struct.get("key4"));
     assertEquals(ConfidenceValue.of(instant), struct.get("key5"));
     assertEquals(ConfidenceValue.of(date), struct.get("key6"));
-    assertEquals(stringList, struct.get("key7"));
+    assertEquals(ConfidenceValue.ofStrings(stringList), struct.get("key7"));
   }
 
   @Test

--- a/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
+++ b/src/test/java/com/spotify/confidence/ConfidenceValueTest.java
@@ -7,8 +7,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ListValue;
 import java.time.Instant;
 import java.time.LocalDate;
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -140,16 +140,32 @@ class ConfidenceValueTest {
   }
 
   @Test
-  public void testListValue() {
-    final ConfidenceValue.List listValue = ConfidenceValue.of(ImmutableList.of("item1", "item2"));
+  public void testStringListValue() {
+    final ConfidenceValue.List listValue =
+        ConfidenceValue.ofStrings(ImmutableList.of("item1", "item2"));
     assertEquals(
         listValue.toProto(),
         com.google.protobuf.Value.newBuilder()
             .setListValue(
                 ListValue.newBuilder()
                     .addAllValues(
-                        Arrays.asList(ConfidenceValue.of("item1"), ConfidenceValue.of("item2"))
-                            .stream()
+                        Stream.of(ConfidenceValue.of("item1"), ConfidenceValue.of("item2"))
+                            .map(ConfidenceValue::toProto)
+                            .collect(Collectors.toList())))
+            .build());
+  }
+
+  @Test
+  public void testBooleanListValue() {
+    final ConfidenceValue.List listValue =
+        ConfidenceValue.ofBooleans(ImmutableList.of(true, false));
+    assertEquals(
+        listValue.toProto(),
+        com.google.protobuf.Value.newBuilder()
+            .setListValue(
+                ListValue.newBuilder()
+                    .addAllValues(
+                        Stream.of(ConfidenceValue.of(true), ConfidenceValue.of(false))
                             .map(ConfidenceValue::toProto)
                             .collect(Collectors.toList())))
             .build());
@@ -250,7 +266,7 @@ class ConfidenceValueTest {
     map.put("timestamp", ConfidenceValue.of(instant));
     map.put("date", ConfidenceValue.of(localDate));
     map.put("boolean", ConfidenceValue.of(false));
-    map.put("list", ConfidenceValue.of(java.util.List.of("item1", "item2")));
+    map.put("list", ConfidenceValue.ofStrings(List.of("item1", "item2")));
     map.put("struct", ConfidenceValue.of(map));
     final ConfidenceValue.Struct struct = ConfidenceValue.of(map);
     assertEquals(


### PR DESCRIPTION
Alternative to #94 

Usage:
```
ConfidenceValue.ofIntegers(ImmutableList.of(3, 5));
```