### PR TITLE
feat: Telemetry for Events (`SDK` metadata)

### DIFF
--- a/src/main/java/com/spotify/confidence/GrpcEventUploader.java
+++ b/src/main/java/com/spotify/confidence/GrpcEventUploader.java
@@ -8,8 +8,6 @@ import com.spotify.confidence.events.v1.PublishEventsRequest;
 import com.spotify.confidence.events.v1.Sdk;
 import com.spotify.confidence.events.v1.SdkId;
 import io.grpc.ManagedChannel;
-import java.io.IOException;
-import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -28,17 +26,11 @@ class GrpcEventUploader implements EventUploader {
     this.managedChannel = managedChannel;
     this.stub = EventsServiceGrpc.newFutureStub(managedChannel);
     this.clock = clock;
-    try {
-      final Properties prop = new Properties();
-      prop.load(this.getClass().getResourceAsStream("/version.properties"));
-      this.sdk =
-          Sdk.newBuilder()
-              .setId(SdkId.SDK_ID_JAVA_CONFIDENCE)
-              .setVersion(prop.getProperty("version"))
-              .build();
-    } catch (IOException e) {
-      throw new RuntimeException("Can't determine version of the SDK", e);
-    }
+    this.sdk =
+        Sdk.newBuilder()
+            .setId(SdkId.SDK_ID_JAVA_CONFIDENCE)
+            .setVersion(SdkUtils.getSdkVersion())
+            .build();
   }
 
   @Override

--- a/src/main/java/com/spotify/confidence/GrpcFlagResolver.java
+++ b/src/main/java/com/spotify/confidence/GrpcFlagResolver.java
@@ -4,9 +4,7 @@ import com.google.common.base.Strings;
 import com.google.protobuf.Struct;
 import com.spotify.confidence.shaded.flags.resolver.v1.*;
 import io.grpc.ManagedChannel;
-import java.io.IOException;
 import java.util.List;
-import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -21,21 +19,12 @@ public class GrpcFlagResolver implements FlagResolver {
     if (Strings.isNullOrEmpty(clientSecret)) {
       throw new IllegalArgumentException("clientSecret must be a non-empty string.");
     }
-
     this.clientSecret = clientSecret;
-
-    try {
-      final Properties prop = new Properties();
-      prop.load(this.getClass().getResourceAsStream("/version.properties"));
-      this.sdk =
-          Sdk.newBuilder()
-              .setId(SdkId.SDK_ID_JAVA_PROVIDER)
-              .setVersion(prop.getProperty("version"))
-              .build();
-    } catch (IOException e) {
-      throw new RuntimeException("Can't determine version of the SDK", e);
-    }
-
+    this.sdk =
+        Sdk.newBuilder()
+            .setId(SdkId.SDK_ID_JAVA_CONFIDENCE)
+            .setVersion(SdkUtils.getSdkVersion())
+            .build();
     this.managedChannel = managedChannel;
     this.stub = FlagResolverServiceGrpc.newFutureStub(managedChannel);
   }

--- a/src/main/java/com/spotify/confidence/GrpcFlagResolver.java
+++ b/src/main/java/com/spotify/confidence/GrpcFlagResolver.java
@@ -22,7 +22,7 @@ public class GrpcFlagResolver implements FlagResolver {
     this.clientSecret = clientSecret;
     this.sdk =
         Sdk.newBuilder()
-            .setId(SdkId.SDK_ID_JAVA_CONFIDENCE)
+            .setId(SdkId.SDK_ID_JAVA_PROVIDER)
             .setVersion(SdkUtils.getSdkVersion())
             .build();
     this.managedChannel = managedChannel;

--- a/src/main/java/com/spotify/confidence/GrpcFlagResolver.java
+++ b/src/main/java/com/spotify/confidence/GrpcFlagResolver.java
@@ -13,8 +13,7 @@ import java.util.concurrent.TimeUnit;
 public class GrpcFlagResolver implements FlagResolver {
   private final ManagedChannel managedChannel;
   private final String clientSecret;
-  private final String SDK_VERSION;
-  private static final SdkId SDK_ID = SdkId.SDK_ID_JAVA_PROVIDER;
+  private final Sdk sdk;
 
   private final FlagResolverServiceGrpc.FlagResolverServiceFutureStub stub;
 
@@ -28,7 +27,11 @@ public class GrpcFlagResolver implements FlagResolver {
     try {
       final Properties prop = new Properties();
       prop.load(this.getClass().getResourceAsStream("/version.properties"));
-      this.SDK_VERSION = prop.getProperty("version");
+      this.sdk =
+          Sdk.newBuilder()
+              .setId(SdkId.SDK_ID_JAVA_PROVIDER)
+              .setVersion(prop.getProperty("version"))
+              .build();
     } catch (IOException e) {
       throw new RuntimeException("Can't determine version of the SDK", e);
     }
@@ -45,7 +48,7 @@ public class GrpcFlagResolver implements FlagResolver {
                     .setClientSecret(this.clientSecret)
                     .addAllFlags(List.of(flag))
                     .setEvaluationContext(context)
-                    .setSdk(Sdk.newBuilder().setId(SDK_ID).setVersion(SDK_VERSION).build())
+                    .setSdk(sdk)
                     .setApply(true)
                     .build()));
   }

--- a/src/main/java/com/spotify/confidence/SdkUtils.java
+++ b/src/main/java/com/spotify/confidence/SdkUtils.java
@@ -1,0 +1,19 @@
+package com.spotify.confidence;
+
+import java.io.IOException;
+import java.util.Properties;
+
+final class SdkUtils {
+
+  private SdkUtils() {}
+
+  static String getSdkVersion() {
+    try {
+      final Properties prop = new Properties();
+      prop.load(SdkUtils.class.getResourceAsStream("/version.properties"));
+      return prop.getProperty("version");
+    } catch (IOException e) {
+      throw new RuntimeException("Can't determine version of the SDK", e);
+    }
+  }
+}

--- a/src/main/proto/confidence/events/v1/api.proto
+++ b/src/main/proto/confidence/events/v1/api.proto
@@ -37,8 +37,12 @@ message PublishEventsRequest {
   google.protobuf.Timestamp send_time = 3 [
     (google.api.field_behavior) = REQUIRED
   ];
-}
 
+  // Information about the SDK used to initiate the request.
+  Sdk sdk = 4 [
+    (google.api.field_behavior) = OPTIONAL
+  ];
+}
 
 message PublishEventsResponse {
   repeated EventError errors = 1;

--- a/src/main/proto/confidence/events/v1/types.proto
+++ b/src/main/proto/confidence/events/v1/types.proto
@@ -38,8 +38,63 @@ message EventError {
   string message = 3;
 
   enum Reason {
-    REASON_UNSPECIFIED = 0; // unknown error
-    EVENT_DEFINITION_NOT_FOUND = 1; // not transient: the event definition was not found
-    EVENT_SCHEMA_VALIDATION_FAILED = 2; // not transient: the schema validation failed
+    // unknown error
+    REASON_UNSPECIFIED = 0;
+    // not transient: the event definition was not found
+    EVENT_DEFINITION_NOT_FOUND = 1;
+    // not transient: the schema validation failed
+    EVENT_SCHEMA_VALIDATION_FAILED = 2;
   }
+}
+
+// (-- api-linter: core::0123::resource-annotation=disabled
+//     aip.dev/not-precedent: SDKs are not internal Confidence resources. --)
+message Sdk {
+  // Identifier of the SDK used to interact with the API.
+  oneof sdk {
+    // Name of a Confidence SDKs.
+    SdkId id = 1;
+    // Custom name for non-Confidence SDKs.
+    string custom_id = 2;
+  }
+
+  // Version of the SDK.
+  string version = 3 [
+    (google.api.field_behavior) = OPTIONAL // TODO: Make REQUIRED again when we're not SDK if default
+  ];
+}
+
+enum SdkId {
+  // Unspecified enum.
+  SDK_ID_UNSPECIFIED = 0;
+  // Confidence OpenFeature Java Provider.
+  SDK_ID_JAVA_PROVIDER = 1;
+  // Confidence OpenFeature Kotlin Provider.
+  SDK_ID_KOTLIN_PROVIDER = 2;
+  // Confidence OpenFeature Swift Provider.
+  SDK_ID_SWIFT_PROVIDER = 3;
+  // Confidence OpenFeature JavaScript Provider for Web (client).
+  SDK_ID_JS_WEB_PROVIDER = 4;
+  // Confidence OpenFeature JavaScript Provider for server.
+  SDK_ID_JS_SERVER_PROVIDER = 5;
+  // Confidence OpenFeature Python Provider.
+  SDK_ID_PYTHON_PROVIDER = 6;
+  // Confidence OpenFeature GO Provider.
+  SDK_ID_GO_PROVIDER = 7;
+  // Confidence OpenFeature Ruby Provider.
+  SDK_ID_RUBY_PROVIDER = 8;
+  // Confidence OpenFeature Rust Provider.
+  SDK_ID_RUST_PROVIDER = 9;
+  // Confidence Java SDK.
+  SDK_ID_JAVA_CONFIDENCE = 10;
+  // Confidence Kotlin SDK.
+  SDK_ID_KOTLIN_CONFIDENCE = 11;
+  // Confidence Swift SDK.
+  SDK_ID_SWIFT_CONFIDENCE = 12;
+  // Confidence JavaScript SDK.
+  SDK_ID_JS_CONFIDENCE = 13;
+  // Confidence Python SDK.
+  SDK_ID_PYTHON_CONFIDENCE = 14;
+  // Confidence GO SDK.
+  SDK_ID_GO_CONFIDENCE = 15;
 }

--- a/src/main/proto/confidence/flags/resolver/v1/types.proto
+++ b/src/main/proto/confidence/flags/resolver/v1/types.proto
@@ -21,7 +21,7 @@ message Sdk {
 
   // Version of the SDK.
   string version = 3 [
-    (google.api.field_behavior) = REQUIRED
+    (google.api.field_behavior) = OPTIONAL // TODO: Make REQUIRED again when we're not SDK if default
   ];
 }
 
@@ -60,4 +60,20 @@ enum SdkId {
   SDK_ID_PYTHON_PROVIDER = 6;
   // Confidence OpenFeature GO Provider.
   SDK_ID_GO_PROVIDER = 7;
+  // Confidence OpenFeature Ruby Provider.
+  SDK_ID_RUBY_PROVIDER = 8;
+  // Confidence OpenFeature Rust Provider.
+  SDK_ID_RUST_PROVIDER = 9;
+  // Confidence Java SDK.
+  SDK_ID_JAVA_CONFIDENCE = 10;
+  // Confidence Kotlin SDK.
+  SDK_ID_KOTLIN_CONFIDENCE = 11;
+  // Confidence Swift SDK.
+  SDK_ID_SWIFT_CONFIDENCE = 12;
+  // Confidence JavaScript SDK.
+  SDK_ID_JS_CONFIDENCE = 13;
+  // Confidence Python SDK.
+  SDK_ID_PYTHON_CONFIDENCE = 14;
+  // Confidence GO SDK.
+  SDK_ID_GO_CONFIDENCE = 15;
 }

--- a/src/test/java/com/spotify/confidence/FeatureProviderTest.java
+++ b/src/test/java/com/spotify/confidence/FeatureProviderTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 final class FeatureProviderTest {
-
   private static Server server;
   private static ManagedChannel channel;
   private static final Value DEFAULT_VALUE = new Value("string-default");


### PR DESCRIPTION
- Sending events also attaches metadata about the SDK ID (`SDK_ID_JAVA_CONFIDENCE`) and SDK VERSION
- Resolving flags emits unchanged metadata about SDK ID (`SDK_ID_JAVA_PROVIDER`) and SDK VERSION 

The SDK ID is used to identify the main logic adopted to perform flag resolving and event sending, rather than reflecting 1:1 the artifact structuring. If/When we will open the flag-resolve API that don't use OpenFeature, the metadata should be changed accordingly to `SDK_ID_JAVA_CONFIDENCE` allowing us to visualize adoption o the different user-facing APIs

Note: invalidates https://github.com/spotify/confidence-openfeature-provider-java/pull/105