### PR TITLE
fix: Response Errors don't trigger retries

### DIFF
--- a/src/main/java/com/spotify/confidence/GrpcEventUploader.java
+++ b/src/main/java/com/spotify/confidence/GrpcEventUploader.java
@@ -48,7 +48,7 @@ class GrpcEventUploader implements EventUploader {
 
     return GrpcUtil.toCompletableFuture(
             stub.withDeadlineAfter(5, TimeUnit.SECONDS).publishEvents(request))
-        .thenApply(publishEventsResponse -> publishEventsResponse.getErrorsCount() == 0)
+        .thenApply(publishEventsResponse -> true)
         .exceptionally(
             (throwable -> {
               // TODO update to use some user-configurable logging


### PR DESCRIPTION
We (currently) consider all Errors in the Response to be **non-transient**, so no event in the batch should be retried due to those. 

Moreover, in the current implementation, a single failing event in the batch would cause the entire batch to _not_ be deleted, thus causing duplicate sendings on retries for the successful events