### PR TITLE
ci: remove token from RP

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -17,7 +17,6 @@ jobs:
         with:
           command: manifest
           release-type: maven
-          token: ${{secrets.GITHUB_TOKEN}}
           default-branch: main
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Having the token in the RP config is potentially prohibiting the resulting Release PR from running workflows, like build/test job